### PR TITLE
examples: update nats.io repo link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ Examples for your applications and/or public libraries.
 
 Examples:
 
-* https://github.com/nats-io/go-nats/tree/master/examples
+* https://github.com/nats-io/nats.go/tree/master/examples
 * https://github.com/docker-slim/docker-slim/tree/master/examples
 * https://github.com/gohugoio/hugo/tree/master/examples
 * https://github.com/hashicorp/packer/tree/master/examples


### PR DESCRIPTION
Update nats example link to the current project, rather than an archived one. Since this is probably the first link people will click on it should go to an actively maintained project.